### PR TITLE
feat: Improve tmux context capture and prompt caching efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ Optional, but highly recommended if you want `ask` command to work more nicely:
        - Anthropic: Set `ASK_SH_ANTHROPIC_MODEL` (default: claude-3-opus-20240229)
     5. If you don't want to use tmux or send your terminal outputs to the LLM provider, set `ASK_SH_NO_PANE=true`
         - If you don't set this variable when you query to `ask`, `ask` command will always recommend you to use tmux.
-    6. Set up your shell environment
+   6. Optional: Configure terminal context capture
+        - By default, ask.sh captures the last 300 lines of your terminal (including scrollback history)
+        - Customize the number of lines with `ASK_SH_CONTEXT_LINES` (e.g., `export ASK_SH_CONTEXT_LINES=500`)
+    7. Set up your shell environment
         - Add `eval "$(ask-sh --init)"` to your rc file (e.g., `~/.bashrc`, `~/.zshrc`)
         - Do not forget to source your shell config file or restart your shell.
-    6. Test the command with `ask hey whats up`
+    8. Test the command with `ask hey whats up`
         - If AI responds with phrases like "As an AI assistant, I can't experience emotions blah blah blah", it means that the setup is done correctly.
 
 # Extras!
@@ -288,8 +291,10 @@ Similar projects:
 
 #### How ask.sh send the current output of terminal?
 
-- ask.sh use `tmux capture-pane -p` to get the current terminal status. Therefore, if you run `ask` in tmux pane, text on the pane will be sent to the OpenAI.
-- This will give AI the context of your request and improve the result.
+- ask.sh uses `tmux capture-pane` to get the terminal history and status. Therefore, if you run `ask` in a tmux pane, terminal text will be sent to your configured LLM provider.
+- By default, the last 300 lines (including scrollback history) are captured with ANSI escape sequences removed for cleaner context.
+- You can customize the number of lines captured by setting `ASK_SH_CONTEXT_LINES` (e.g., `export ASK_SH_CONTEXT_LINES=500`).
+- This gives AI the context of your request and improves the result quality.
 - If you don't want to use this feature, set `ASK_SH_NO_PANE=true` in your shell.
 
 #### Privacy concerns?
@@ -339,6 +344,35 @@ The prompts support the following variables that will be replaced with actual va
 - `{user_input}`: User's input/question
 
 See the default prompts in [src/prompt.rs](src/prompts.rs) for examples.
+
+#### Environment Variables Reference
+
+Here's a complete list of environment variables you can use to customize ask.sh:
+
+**LLM Provider Configuration:**
+- `ASK_SH_LLM_PROVIDER`: Choose provider (`openai` or `anthropic`, default: `openai`)
+- `ASK_SH_OPENAI_API_KEY`: OpenAI API key
+- `ASK_SH_OPENAI_MODEL`: OpenAI model name (default: `gpt-4o`)
+- `ASK_SH_OPENAI_BASE_URL`: Custom OpenAI-compatible endpoint URL
+- `ASK_SH_ANTHROPIC_API_KEY`: Anthropic API key
+- `ASK_SH_ANTHROPIC_MODEL`: Anthropic model name (default: `claude-3-5-sonnet-latest`)
+
+**Terminal Context Configuration:**
+- `ASK_SH_NO_PANE`: Disable terminal context capture (`true`/`false`, default: `false`)
+- `ASK_SH_CONTEXT_LINES`: Number of terminal lines to capture (default: `300`)
+
+**Output Configuration:**
+- `ASK_SH_NO_SUGGEST`: Disable command suggestions (`true`/`false`, default: `false`)
+
+**Prompt Customization:**
+- `ASK_SH_SYSTEM_PROMPT_WITH_PANE`: Custom system prompt when terminal context is available
+- `ASK_SH_USER_PROMPT_WITH_PANE`: Custom user prompt format when terminal context is available
+- `ASK_SH_SYSTEM_PROMPT_WITHOUT_PANE`: Custom system prompt without terminal context
+- `ASK_SH_USER_PROMPT_WITHOUT_PANE`: Custom user prompt format without terminal context
+
+**Development:**
+- `ASK_SH_DEBUG`: Enable debug mode (`true`/`false`, default: `false`)
+- `ASK_SH_NO_UPDATE`: Disable update check (`true`/`false`, default: `false`)
 
 # Contributing
 - Of course, we welcome contributions! Please feel free to open an issue or submit a pull request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ const ARG_INIT: &str = "--init";
 const ENV_DEBUG: &str = "ASK_SH_DEBUG";
 const ENV_NO_PANE: &str = "ASK_SH_NO_PANE";
 const ENV_NO_SUGGEST: &str = "ASK_SH_NO_SUGGEST";
+const ENV_CONTEXT_LINES: &str = "ASK_SH_CONTEXT_LINES";
 
 // LLM provider settings
 const ENV_LLM_PROVIDER: &str = "ASK_SH_LLM_PROVIDER";
@@ -315,9 +316,18 @@ fn main() {
                 }
             }
             if in_tmux {
+                // Get context lines from env var, default to 300
+                let context_lines = env::var(ENV_CONTEXT_LINES)
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .unwrap_or(300);
+
                 match std::process::Command::new("tmux")
                     .arg("capture-pane")
-                    .arg("-p")
+                    .arg("-e")  // Remove ANSI escape sequences
+                    .arg("-p")  // Print to stdout
+                    .arg("-S")  // Start line (negative = scrollback)
+                    .arg(format!("-{}", context_lines))
                     .output()
                 {
                     Ok(output) => pane_text = String::from_utf8_lossy(&output.stdout).to_string(),

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -52,6 +52,7 @@ Note that the user is operating on a {user_arch} machine, using {user_shell} on 
 const USER_PROMPT_WITH_PANE: &str = r#"
 Terminal state:
 {pane_text}
+
 User's request:
 {user_input}
 "#;


### PR DESCRIPTION
- Increase default context capture to 300 lines (from visible pane only)
- Add ASK_SH_CONTEXT_LINES env var to customize context size
- Add -e flag to remove ANSI escape sequences from captured output
- Optimize USER_PROMPT_WITH_PANE for better LLM prompt caching:
  - Terminal state first (old history = cacheable prefix)
  - User request last (always varies)
  - This structure maximizes cache hits on historical terminal output

Technical changes:
- main.rs: Enhanced tmux capture-pane with -S and -e flags
- prompts.rs: Keep pane_text before user_input for cache efficiency